### PR TITLE
  Make extension compatible with the latest Feedly version

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -4,7 +4,7 @@
    */
   function eachFeedlyUrl(callback) {
     var link_attribute = "data-alternate-link";
-    var links = document.querySelectorAll("div[" + link_attribute + "]");
+    var links = document.querySelectorAll("article[" + link_attribute + "]");
     for (var i = 0, size = links.length; i < size; i++) {
       var link = links[i];
       var url = link.getAttribute(link_attribute);


### PR DESCRIPTION
Fixes https://mobile.twitter.com/dsush/status/1354603724346454016

See upstream fix https://github.com/splattael/chrome-feedly-tabs/commit/b088b75623e1eb101fe340b085499ffc2dd27c9a

BTW, thanks for maintaining this extension :bow: 

I've just discontinued the very old and unmaintained version of the original [FireFox addon](https://github.com/splattael/firefox-feedly-tabs) and linked your repository :heart: 